### PR TITLE
exit 1 if we can't list events

### DIFF
--- a/examples/contracts/DrandCaller.sol
+++ b/examples/contracts/DrandCaller.sol
@@ -66,9 +66,9 @@ contract DrandCaller is LilypadCallerInterface {
 
     function lilypadCancelled(
         address _from,
-        uint _jobId,
+        uint,
         string calldata _errorMsg
-    ) external override {
+    ) external override view {
         require(_from == address(bridge));
         console.log(_errorMsg);
     }

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -9,11 +9,31 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@openzeppelin/contracts": "^4.8.2",
+        "@openzeppelin/contracts-upgradeable": "^4.8.2",
         "lilypad": "file:../hardhat"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^2.0.1",
         "hardhat": "^2.12.7"
+      }
+    },
+    "../hardhat": {
+      "name": "lilypad",
+      "version": "0.1.0",
+      "dependencies": {
+        "@openzeppelin/contracts": "^4.8.1",
+        "@openzeppelin/contracts-upgradeable": "^4.8.1",
+        "dotenv": "^16.0.3"
+      },
+      "devDependencies": {
+        "@nomicfoundation/hardhat-toolbox": "^2.0.1",
+        "@nomiclabs/hardhat-ethers": "^2.2.2",
+        "@openzeppelin/hardhat-upgrades": "^1.22.1",
+        "ethers": "^5.7.2",
+        "hardhat": "^2.12.6",
+        "install": "^0.13.0",
+        "npm": "^9.4.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1610,14 +1630,14 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.1.tgz",
-      "integrity": "sha512-xQ6eUZl+RDyb/FiZe1h+U7qr/f4p/SrTSQcTPH2bjur3C5DbuW/zFgCU/b1P/xcIaEqJep+9ju4xDRi3rmChdQ=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.2.tgz",
+      "integrity": "sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.1.tgz",
-      "integrity": "sha512-1wTv+20lNiC0R07jyIAbHU7TNHKRwGiTGRfiNnA8jOWjKT98g5OgLpYWOi40Vgpk8SPLA9EvfJAbAeIyVn+7Bw=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.2.tgz",
+      "integrity": "sha512-zIggnBwemUmmt9IS73qxi+tumALxCY4QEs3zLCII78k0Gfse2hAOdAkuAeLUzvWUpneMUfFE5sGHzEUSTvn4Ag=="
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -3274,14 +3294,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -5744,13 +5756,8 @@
       }
     },
     "node_modules/lilypad": {
-      "version": "0.1.0",
-      "resolved": "file:../hardhat",
-      "dependencies": {
-        "@openzeppelin/contracts": "^4.8.1",
-        "@openzeppelin/contracts-upgradeable": "^4.8.1",
-        "dotenv": "^16.0.3"
-      }
+      "resolved": "../hardhat",
+      "link": true
     },
     "node_modules/locate-path": {
       "version": "2.0.0",
@@ -10401,14 +10408,14 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.1.tgz",
-      "integrity": "sha512-xQ6eUZl+RDyb/FiZe1h+U7qr/f4p/SrTSQcTPH2bjur3C5DbuW/zFgCU/b1P/xcIaEqJep+9ju4xDRi3rmChdQ=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.2.tgz",
+      "integrity": "sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.1.tgz",
-      "integrity": "sha512-1wTv+20lNiC0R07jyIAbHU7TNHKRwGiTGRfiNnA8jOWjKT98g5OgLpYWOi40Vgpk8SPLA9EvfJAbAeIyVn+7Bw=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.2.tgz",
+      "integrity": "sha512-zIggnBwemUmmt9IS73qxi+tumALxCY4QEs3zLCII78k0Gfse2hAOdAkuAeLUzvWUpneMUfFE5sGHzEUSTvn4Ag=="
     },
     "@scure/base": {
       "version": "1.1.1",
@@ -11733,11 +11740,6 @@
       "requires": {
         "path-type": "^4.0.0"
       }
-    },
-    "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -13655,11 +13657,18 @@
       }
     },
     "lilypad": {
-      "version": "0.1.0",
+      "version": "file:../hardhat",
       "requires": {
+        "@nomicfoundation/hardhat-toolbox": "^2.0.1",
+        "@nomiclabs/hardhat-ethers": "^2.2.2",
         "@openzeppelin/contracts": "^4.8.1",
         "@openzeppelin/contracts-upgradeable": "^4.8.1",
-        "dotenv": "^16.0.3"
+        "@openzeppelin/hardhat-upgrades": "^1.22.1",
+        "dotenv": "^16.0.3",
+        "ethers": "^5.7.2",
+        "hardhat": "^2.12.6",
+        "install": "^0.13.0",
+        "npm": "^9.4.0"
       }
     },
     "locate-path": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,6 +13,8 @@
     "hardhat": "^2.12.7"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "^4.8.2",
+    "@openzeppelin/contracts-upgradeable": "^4.8.2",
     "lilypad": "file:../hardhat"
   }
 }


### PR DESCRIPTION
We were seeing strange errors talking about how we can listen for events further back than 24 hours.

The theory is that the network was done for a period of time but the process kept spinning holding onto the old block number.

When the network came back - the in memory block number is now > 24 hours old and the JSON RPC errors saying `you cannot go that far back in time` - and then it death looped because it keeps asking for the old block number

If we get any kind of error asking for block data - let's exit and let systemd restart us to ask again - this should avoid the deadlock we were seeing in prod